### PR TITLE
DelegateesParam: First pass implementation

### DIFF
--- a/src/DelegateesParam.ts
+++ b/src/DelegateesParam.ts
@@ -1,0 +1,37 @@
+/*
+ * lib-ical
+ * Copyright (C) 2017 Mark Stenglein
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import Parameter from "./Parameter";
+
+/**
+ * DelegateesParam Class (Chapter x.x.x)
+ *
+ * - Purpose: 
+ *
+ * - Format Definition:
+ *
+ * - Description:
+ *
+ * - Example:
+ *
+ *
+ * @since 0.1.0
+ * @author David Haynes <dhaynes3@gmu.edu>
+ */
+export default class DelegateesParam extends Parameter {
+
+}

--- a/src/DelegateesParam.ts
+++ b/src/DelegateesParam.ts
@@ -26,9 +26,9 @@ import Parameter from "./Parameter";
  * - Format Definition: This property parameter is defined by the following
  *   notation:
  *
- *      - deltoparam = "DELEGATED-TO" "=" DQUOTE cal-address 
+ *      - deltoparam = "DELEGATED-TO" "=" DQUOTE cal-address
  *                      DQUOTE *("," DQUOTE cal-address DQUOTE)
- * 
+ *
  * - Description:
  *     - The parameter is specified on properties of the CAL-ADDRESS value
  *       type.
@@ -37,12 +37,12 @@ import Parameter from "./Parameter";
  *       specified by the property.
  *     - The individual calendar address parameter values MUST each be specified
  *       in a quoted-string.
- * 
+ *
  * - Example:
  *
  *     ATTENDEE;DELEGATED-TO="mailto:jdoe@example.com","mailto:
  *      jqpublic@example.com":mailto:jsmith@example.com
- * 
+ *
  * @since 0.1.0
  * @author David Haynes <dhaynes3@gmu.edu>
  */
@@ -59,7 +59,7 @@ export default class DelegateesParam extends Parameter {
 
     /**
      * Simply returns the current delegatees, as a string array.
-     * 
+     *
      * @since 0.1.0
      * @author David Haynes <dhaynes3@gmu.edu>
      */
@@ -70,7 +70,7 @@ export default class DelegateesParam extends Parameter {
     /**
      * Sets the private _delegatees and also writes the "mailto:" to the
      * front of each delegatee before writing super.paramValues
-     * 
+     *
      * @since 0.1.0
      * @author David Haynes <dhaynes3@gmu.edu>
      */
@@ -87,3 +87,4 @@ export default class DelegateesParam extends Parameter {
         this._delegatees = newDelegatees;
     }
 }
+

--- a/src/DelegateesParam.ts
+++ b/src/DelegateesParam.ts
@@ -18,17 +18,31 @@
 import Parameter from "./Parameter";
 
 /**
- * DelegateesParam Class (Chapter x.x.x)
+ * DelegateesParam Class (Chapter 3.2.5)
  *
- * - Purpose: 
+ * - Purpose: To specify the calendar users to whom the calendar user
+ *   specified by the property has delegated participation.
  *
- * - Format Definition:
+ * - Format Definition: This property parameter is defined by the following
+ *   notation:
  *
+ *      - deltoparam = "DELEGATED-TO" "=" DQUOTE cal-address 
+ *                      DQUOTE *("," DQUOTE cal-address DQUOTE)
+ * 
  * - Description:
- *
+ *     - The parameter is specified on properties of the CAL-ADDRESS value
+ *       type.
+ *     - This parameter specifies those calendar users whom have been delegated
+ *       participation in a group-scheduled event or to-do by the calendar user
+ *       specified by the property.
+ *     - The individual calendar address parameter values MUST each be specified
+ *       in a quoted-string.
+ * 
  * - Example:
  *
- *
+ *     ATTENDEE;DELEGATED-TO="mailto:jdoe@example.com","mailto:
+ *      jqpublic@example.com":mailto:jsmith@example.com
+ * 
  * @since 0.1.0
  * @author David Haynes <dhaynes3@gmu.edu>
  */

--- a/src/DelegateesParam.ts
+++ b/src/DelegateesParam.ts
@@ -47,5 +47,43 @@ import Parameter from "./Parameter";
  * @author David Haynes <dhaynes3@gmu.edu>
  */
 export default class DelegateesParam extends Parameter {
+    private _delegatees: string[];
 
+    constructor(delegatees: string | string[]) {
+        super("DELEGATED-TO", []);
+
+        // Converts single string object to an array.
+        delegatees = (delegatees instanceof Array) ? delegatees : [delegatees];
+        this.delegatees = delegatees;
+    }
+
+    /**
+     * Simply returns the current delegatees, as a string array.
+     * 
+     * @since 0.1.0
+     * @author David Haynes <dhaynes3@gmu.edu>
+     */
+    get delegatees(): string[] {
+        return this._delegatees;
+    }
+
+    /**
+     * Sets the private _delegatees and also writes the "mailto:" to the
+     * front of each delegatee before writing super.paramValues
+     * 
+     * @since 0.1.0
+     * @author David Haynes <dhaynes3@gmu.edu>
+     */
+    set delegatees(newDelegatees: string[]) {
+        // Ensure each delegatee is valid QSafeChar String
+        if (!newDelegatees.every(Parameter.isQSafeChar))
+            throw new TypeError("Delegatee must be QSafeChars");
+
+        // Construct paramValues for generation
+        this.paramValues = newDelegatees.map(
+            delegatee => `"mailto:${delegatee}"`);
+
+        // Saves the given values for the getter funciton
+        this._delegatees = newDelegatees;
+    }
 }

--- a/test/DelegateesParam.spec.ts
+++ b/test/DelegateesParam.spec.ts
@@ -22,8 +22,98 @@ import "mocha";
 /**
  * Test the DelegateesParam class.
  */
-describe("DelegatorsParam:", () => {
+describe("DelegateesParam:", () => {
     it("Should exist", () => {
         expect(DelegateesParam).to.exist;
     });
+
+    describe("Constructor:", () => {
+        it("Should create an object", () => {
+            const delegatee: string = "Mark Stenglein";
+            const delegateeParam: DelegateesParam = new DelegateesParam(delegatee);
+
+            expect(delegateeParam).to.exist;
+        });
+
+        it("Should convert string to string[]", () => {
+            const delegatee: string = "Mark Stenglein";
+            const testParam: DelegateesParam = new DelegateesParam(delegatee);
+
+            expect(testParam.delegatees).to.be.deep.equal([delegatee]);
+        });
+
+        it("Should not add extra layer to input array", () => {
+            const delegatees: string[] = ["Mark", "Stenglein"];
+            const testParam: DelegateesParam = new DelegateesParam(delegatees);
+
+            expect(testParam.delegatees).to.not.deep.equal([delegatees]);
+            expect(testParam.delegatees).to.deep.equal(delegatees);
+        });
+    });
+
+    describe("Setter/Getter:", () => {
+        it("Sets delegatees", () => {
+            const delegatees: string[] = ["mark@stengle.in"];
+            const testParam: DelegateesParam = new DelegateesParam("te@s.t");
+            testParam.delegatees = delegatees;
+
+            expect(testParam.delegatees).to.exist;
+        });
+
+        it("Sets delegatees with no change", () => {
+            const delegatees: string[] = ["mark@stengle.in"];
+            const testParam: DelegateesParam = new DelegateesParam("te@s.t");
+            testParam.delegatees = delegatees;
+
+            expect(testParam.delegatees).to.be.deep.equal(delegatees);
+        });
+
+        it("Sets paramValues as well", () => {
+            const delegatees: string[] = ["mark@stengle.in"];
+            const testParam: DelegateesParam = new DelegateesParam("te@s.t");
+            testParam.delegatees = delegatees;
+
+            expect(testParam.paramValues).to.exist;
+        });
+
+        it("Sets paramValues correctly", () => {
+            const delegatees: string[] = ["mark@stengle.in", "te@s.t"];
+            const testParam: DelegateesParam = new DelegateesParam("diff@ema.il");
+            testParam.delegatees = delegatees;
+
+            const expected: string[] = ["\"mailto:mark@stengle.in\"",
+                                        "\"mailto:te@s.t\""];
+            expect(testParam.paramValues).to.be.deep.equal(expected);
+        });
+
+        describe("Rejects invalid delegatee params:", () => {
+            it("DQUOTES", () => {
+                const delegatees: string[] = ["mark\"@stengle.in"];
+
+                expect(() => {
+                    new DelegateesParam(delegatees);
+                }).to.throw("Delegatee must be QSafeChars");
+            });
+        });
+    });
+
+    describe("Generator:", () => {
+        it("Properly Generates output for single delegatee", () => {
+            const delegatees: string[] = ["mark@stengle.in"];
+            const testParam: DelegateesParam = new DelegateesParam(delegatees);
+
+            const actual: string = "DELEGATED-TO=\"mailto:mark@stengle.in\"";
+            expect(testParam.generate()).to.be.equal(actual);
+        });
+
+        it("Properly Generates output for multiple delegatees", () => {
+            const delegatees: string[] = ["one@one.com", "two@two.com"];
+            const testParam: DelegateesParam = new DelegateesParam(delegatees);
+
+            const actual: string = "DELEGATED-TO=\"mailto:one@one.com\"," +
+                "\"mailto:two@two.com\"";
+            expect(testParam.generate()).to.be.equal(actual);
+        });
+    });
+
 });

--- a/test/DelegateesParam.spec.ts
+++ b/test/DelegateesParam.spec.ts
@@ -1,0 +1,29 @@
+/*
+* lib-ical
+* Copyright (C) 2017 Mark Stenglein
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import DelegateesParam from "../src/DelegateesParam";
+import { expect } from "chai";
+import "mocha";
+
+/**
+ * Test the DelegateesParam class.
+ */
+describe("DelegatorsParam:", () => {
+    it("Should exist", () => {
+        expect(DelegateesParam).to.exist;
+    });
+});

--- a/test/DelegateesParam.spec.ts
+++ b/test/DelegateesParam.spec.ts
@@ -117,3 +117,4 @@ describe("DelegateesParam:", () => {
     });
 
 });
+


### PR DESCRIPTION
Adds in the Delegatees Parameter from RFC 5545 section 3.2.5.

Closes #2 

```
[~/d/S/lib-ical]─[⎇ 2-delegatees]─[±]─(1)-> npm test

> lib-ics@0.0.1 test /home/dhaynes/development/SRCT/lib-ical
> NODE_ENV=test nyc --reporter=text mocha -R nyan --recursive --compilers ts:ts-node/register

File [/home/dhaynes/development/SRCT/lib-ical/src/ICalElement.ts] ignored, nothing could be mapped
 113 -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-__,------,
 0   -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-__|  /\_/\
 0   -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_~|_( ^ .^)
     -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ ""  ""

  113 passing (91ms)

---------------------|----------|----------|----------|----------|----------------|
File                 |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
---------------------|----------|----------|----------|----------|----------------|
All files            |      100 |    97.62 |      100 |      100 |                |
 AltRepParam.ts      |      100 |      100 |      100 |      100 |                |
 CalUserTypeParam.ts |      100 |      100 |      100 |      100 |                |
 CommonNameParam.ts  |      100 |      100 |      100 |      100 |                |
 ContentLine.ts      |      100 |      100 |      100 |      100 |                |
 DelegateesParam.ts  |      100 |      100 |      100 |      100 |                |
 DelegatorsParam.ts  |      100 |      100 |      100 |      100 |                |
 Parameter.ts        |      100 |    92.31 |      100 |      100 |                |
 util.ts             |      100 |      100 |      100 |      100 |                |
---------------------|----------|----------|----------|----------|----------------|
```